### PR TITLE
Improved logic for Legacy_ErrorException with multiple errors

### DIFF
--- a/src/php/Phix_Project/ExceptionsLib/Legacy/ErrorException.php
+++ b/src/php/Phix_Project/ExceptionsLib/Legacy/ErrorException.php
@@ -46,8 +46,15 @@ namespace Phix_Project\ExceptionsLib;
 
 class Legacy_ErrorException extends E5xx_InternalServerErrorException
 {
+        private $errorCode;
+        
         public function __construct($errno, $errstr, $errfile, $errline = 0)
         {
                 \Exception::__construct('Legacy PHP error: ' . $errno . ': ' . $errstr . ': at line ' . $errline . ' in file ' . $errfile, 500);
+                $this->errorCode = $errno;
+        }
+        
+        public function getErrorCode() {
+                return $this->errorCode;
         }
 }

--- a/src/php/Phix_Project/ExceptionsLib/Legacy/ErrorHandler.php
+++ b/src/php/Phix_Project/ExceptionsLib/Legacy/ErrorHandler.php
@@ -50,6 +50,9 @@ class Legacy_ErrorHandler
         
         public function run($callback)
         {
+                // clear the exceptionToThrow from a previous run
+                $this->exceptionToThrow = null;
+                
                 // execute the code, inside our wrapper
                 set_error_handler(array($this, 'handleLegacyError'));
                 $return = $callback();
@@ -66,32 +69,5 @@ class Legacy_ErrorHandler
         
         public function handleLegacyError($errno, $errstr, $errfile, $errline = 0, $errcontext = null)
         {
-                // work out what kind of exception to throw
-                switch($errno)
-                {
-                        case E_CORE_ERROR:
-                        case E_CORE_WARNING:
-                        case E_COMPILE_ERROR:
-                        case E_COMPILE_WARNING:
-                        case E_STRICT:
-                        case E_DEPRECATED:
-                        case E_USER_DEPRECATED:
-                                // we do not want to throw an exception
-                                // for any of these
-                                $this->exceptionToThrow = null;
-                                break;
-                        
-                        case E_ERROR:
-                        case E_PARSE:
-                        case E_WARNING:
-                        case E_NOTICE:
-                        case E_USER_ERROR:
-                        case E_USER_NOTICE:
-                                // this is the default if a user calls trigger_error() only with a message
-                        case E_USER_WARNING:
-                        case E_RECOVERABLE_ERROR:
-                        default:
-                                $this->exceptionToThrow = new Legacy_ErrorException($errno, $errstr, $errfile, $errline);
-                }
-        }
-}
+                // report the highest level exception (lowest value)
+                if ($this->exceptionToThrow && $this->exceptionToThrow->getErrorCode() < $errno)

--- a/src/php/Phix_Project/ExceptionsLib/Legacy/ErrorHandler.php
+++ b/src/php/Phix_Project/ExceptionsLib/Legacy/ErrorHandler.php
@@ -70,4 +70,36 @@ class Legacy_ErrorHandler
         public function handleLegacyError($errno, $errstr, $errfile, $errline = 0, $errcontext = null)
         {
                 // report the highest level exception (lowest value)
-                if ($this->exceptionToThrow && $this->exceptionToThrow->getErrorCode() < $errno)
+                if ($this->exceptionToThrow && $this->exceptionToThrow->getErrorCode() < $errno) {
+                        return;
+                }
+                
+                // work out what kind of exception to throw
+                switch($errno)
+                {
+                        case E_CORE_ERROR:
+                        case E_CORE_WARNING:
+                        case E_COMPILE_ERROR:
+                        case E_COMPILE_WARNING:
+                        case E_STRICT:
+                        case E_DEPRECATED:
+                        case E_USER_DEPRECATED:
+                                // we do not want to throw an exception
+                                // for any of these
+                                $this->exceptionToThrow = null;
+                                break;
+                        
+                        case E_ERROR:
+                        case E_PARSE:
+                        case E_WARNING:
+                        case E_NOTICE:
+                        case E_USER_ERROR:
+                        case E_USER_NOTICE:
+                                // this is the default if a user calls trigger_error() only with a message
+                        case E_USER_WARNING:
+                        case E_RECOVERABLE_ERROR:
+                        default:
+                                $this->exceptionToThrow = new Legacy_ErrorException($errno, $errstr, $errfile, $errline);
+                }
+        }
+}

--- a/src/php/Phix_Project/ExceptionsLib/Legacy/ErrorHandler.php
+++ b/src/php/Phix_Project/ExceptionsLib/Legacy/ErrorHandler.php
@@ -86,7 +86,6 @@ class Legacy_ErrorHandler
                         case E_USER_DEPRECATED:
                                 // we do not want to throw an exception
                                 // for any of these
-                                $this->exceptionToThrow = null;
                                 break;
                         
                         case E_ERROR:


### PR DESCRIPTION
I was just reviewing your code for interest sake and noticed that your legacy error handler will drop previous errors in the case of a single function that generates more than one.

Figured this would be the best way to notify you but tried to fix it using github's built-in editor so made a little bit of a mess - will likely be easier just to merge my three commits together if you choose to bring it in.
